### PR TITLE
Convert to Swift 2.0

### DIFF
--- a/Lua Tests/Info.plist
+++ b/Lua Tests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.tinyrobotsoftware.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Lua Tests/Lua_Tests.swift
+++ b/Lua Tests/Lua_Tests.swift
@@ -22,7 +22,7 @@ class Lua_Tests: XCTestCase {
             let fragments = subject.componentsSeparatedByString(separator)
             
             let results = vm.createTable()
-            for (i, fragment) in enumerate(fragments) {
+            for (i, fragment) in fragments.enumerate() {
                 results[i+1] = fragment
             }
             return .Value(results)

--- a/Lua.xcodeproj/project.pbxproj
+++ b/Lua.xcodeproj/project.pbxproj
@@ -394,7 +394,9 @@
 		944A32F91A475A6300BF8675 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0620;
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Tiny Robot Software";
 				TargetAttributes = {
 					944A33001A475A6400BF8675 = {
@@ -524,6 +526,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -634,6 +637,7 @@
 				);
 				INFOPLIST_FILE = "Lua Tests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.tinyrobotsoftware.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -650,6 +654,7 @@
 				);
 				INFOPLIST_FILE = "Lua Tests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.tinyrobotsoftware.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -682,6 +687,7 @@
 				94697A981AC712CB0047447A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Lua/Function.swift
+++ b/Lua/Function.swift
@@ -26,7 +26,7 @@ public class Function: StoredValue {
             var values = [Value]()
             let numReturnValues = vm.stackSize() - originalStackTop
             
-            for i in 0..<numReturnValues {
+            for _ in 0..<numReturnValues {
                 let v = vm.popValue(originalStackTop+1)!
                 values.append(v)
             }

--- a/Lua/Number.swift
+++ b/Lua/Number.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class Number: StoredValue, DebugPrintable {
+public class Number: StoredValue, CustomDebugStringConvertible {
     
     override public func kind() -> Kind { return .Number }
     

--- a/Lua/Table.swift
+++ b/Lua/Table.swift
@@ -53,7 +53,7 @@ public class Table: StoredValue {
         vm.pop() // thing
     }
     
-    public func asTupleArray<K1: Value, V1: Value, K2: Value, V2: Value>(_ kfn: K1 -> K2 = {$0 as! K2}, _ vfn: V1 -> V2 = {$0 as! V2}) -> [(K2, V2)] {
+    public func asTupleArray<K1: Value, V1: Value, K2: Value, V2: Value>(kfn: K1 -> K2 = {$0 as! K2}, _ vfn: V1 -> V2 = {$0 as! V2}) -> [(K2, V2)] {
         var v = [(K2, V2)]()
         for key in keys() {
             let val = self[key]
@@ -64,7 +64,7 @@ public class Table: StoredValue {
         return v
     }
     
-    public func asDictionary<K1: Value, V1: Value, K2: Value, V2: Value where K2: Hashable>(_ kfn: K1 -> K2 = {$0 as! K2}, _ vfn: V1 -> V2 = {$0 as! V2}) -> [K2: V2] {
+    public func asDictionary<K1: Value, V1: Value, K2: Value, V2: Value where K2: Hashable>(kfn: K1 -> K2 = {$0 as! K2}, _ vfn: V1 -> V2 = {$0 as! V2}) -> [K2: V2] {
         var v = [K2: V2]()
         for (key, val) in asTupleArray(kfn, vfn) {
             v[key] = val
@@ -81,7 +81,7 @@ public class Table: StoredValue {
         if dict.count == 0 { return sequence }
         
         // ensure table has no holes and keys start at 1
-        let sortedKeys = sorted(dict.keys, <)
+        let sortedKeys = dict.keys.sort(<)
         if [Int64](1...sortedKeys.last!) != sortedKeys { return sequence }
         
         // append values to the array, in order

--- a/Lua/Userdata.swift
+++ b/Lua/Userdata.swift
@@ -57,7 +57,7 @@ public class CustomType<T: CustomTypeInstance>: Table {
     
     public func createMethod(var typeCheckers: [TypeChecker], _ fn: (T, Arguments) -> SwiftReturnValue) -> Function {
         typeCheckers.insert(CustomType<T>.arg, atIndex: 0)
-        return vm.createFunction(typeCheckers) { (var args: Arguments) in
+        return vm.createFunction(typeCheckers) { (args: Arguments) in
             let o: T = args.customType()
             return fn(o, args)
         }


### PR DESCRIPTION
As of Xcode 7 beta 3, attempting to build lua4swift no longer crashes the compiler. This is just the automated conversion, plus a small fix for the function pointer that gets passed to lua_pushcclosure. All two tests pass.