### PR TITLE
Remove unnecessary import Cocoa line

### DIFF
--- a/Lua Tests/Lua_Tests.swift
+++ b/Lua Tests/Lua_Tests.swift
@@ -19,24 +19,24 @@ class Lua_Tests: XCTestCase {
         
         stringxLib["split"] = vm.createFunction([String.arg, String.arg]) { args in
             let (subject, separator) = (args.string, args.string)
-            let fragments = subject.componentsSeparatedByString(separator)
+            let fragments = subject.components(separatedBy: separator)
             
             let results = vm.createTable()
-            for (i, fragment) in fragments.enumerate() {
+            for (i, fragment) in fragments.enumerated() {
                 results[i+1] = fragment
             }
-            return .Value(results)
+            return .value(results)
         }
         
         vm.globals["stringx"] = stringxLib
         
         switch vm.eval("return stringx.split('hello world', ' ')", args: []) {
-        case let .Values(values):
+        case let .values(values):
             XCTAssertEqual(values.count, 1)
             XCTAssert(values[0] is Table)
             let array: [String] = (values[0] as! Table).asSequence()
             XCTAssertEqual(array, ["hello", "world"])
-        case let .Error(e):
+        case let .error(e):
             XCTFail(e)
         }
     }
@@ -57,11 +57,11 @@ class Lua_Tests: XCTestCase {
             type["setName"] = type.createMethod([String.arg]) {
                 note, args in
                 note.name = args.string
-                return .Nothing
+                return .nothing
             }
             type["getName"] = type.createMethod([]) {
                 note, args in
-                return .Value(note.name)
+                return .value(note.name)
             }
         }
         
@@ -70,7 +70,7 @@ class Lua_Tests: XCTestCase {
             let note = Note()
             note.name = args.string
             let data = vm.createUserdata(note)
-            return .Value(data)
+            return .value(data)
         }
 
         // setup the note class

--- a/Lua.xcodeproj/project.pbxproj
+++ b/Lua.xcodeproj/project.pbxproj
@@ -396,14 +396,16 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Tiny Robot Software";
 				TargetAttributes = {
 					944A33001A475A6400BF8675 = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 0800;
 					};
 					94697A8D1AC712CB0047447A = {
 						CreatedOnToolsVersion = 6.2;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -520,8 +522,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
@@ -529,6 +533,7 @@
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -561,8 +566,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
@@ -570,6 +577,7 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -579,6 +587,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -601,6 +610,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = Lua/Lua.h;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -620,6 +630,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = Lua/Lua.h;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -640,6 +651,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tinyrobotsoftware.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -656,6 +668,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tinyrobotsoftware.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Lua/Boolean.swift
+++ b/Lua/Boolean.swift
@@ -2,14 +2,14 @@ import Foundation
 
 extension Bool: Value {
     
-    public func push(vm: VirtualMachine) {
+    public func push(_ vm: VirtualMachine) {
         lua_pushboolean(vm.vm, self ? 1 : 0)
     }
     
-    public func kind() -> Kind { return .Boolean }
+    public func kind() -> Kind { return .boolean }
     
-    public static func arg(vm: VirtualMachine, value: Value) -> String? {
-        if value.kind() != .Boolean { return "boolean" }
+    public static func arg(_ vm: VirtualMachine, value: Value) -> String? {
+        if value.kind() != .boolean { return "boolean" }
         return nil
     }
     

--- a/Lua/ExtraTypes.swift
+++ b/Lua/ExtraTypes.swift
@@ -2,18 +2,18 @@ import Foundation
 
 extension NSPoint: Value {
     
-    public func push(vm: VirtualMachine) {
+    public func push(_ vm: VirtualMachine) {
         let t = vm.createTable()
         t["x"] = Double(self.x)
         t["y"] = Double(self.y)
         t.push(vm)
     }
     
-    public func kind() -> Kind { return .Table }
+    public func kind() -> Kind { return .table }
     
-    private static let typeName: String = "point (table with numeric keys x,y)"
-    public static func arg(vm: VirtualMachine, value: Value) -> String? {
-        if value.kind() != .Table { return typeName }
+    fileprivate static let typeName: String = "point (table with numeric keys x,y)"
+    public static func arg(_ vm: VirtualMachine, value: Value) -> String? {
+        if value.kind() != .table { return typeName }
         if let result = Table.arg(vm, value: value) { return result }
         let t = value as! Table
         if !(t["x"] is Number) || !(t["y"] is Number) { return typeName }
@@ -24,18 +24,18 @@ extension NSPoint: Value {
 
 extension NSSize: Value {
     
-    public func push(vm: VirtualMachine) {
+    public func push(_ vm: VirtualMachine) {
         let t = vm.createTable()
         t["w"] = Double(self.width)
         t["h"] = Double(self.height)
         t.push(vm)
     }
     
-    public func kind() -> Kind { return .Table }
+    public func kind() -> Kind { return .table }
     
-    private static let typeName: String = "size (table with numeric keys w,h)"
-    public static func arg(vm: VirtualMachine, value: Value) -> String? {
-        if value.kind() != .Table { return typeName }
+    fileprivate static let typeName: String = "size (table with numeric keys w,h)"
+    public static func arg(_ vm: VirtualMachine, value: Value) -> String? {
+        if value.kind() != .table { return typeName }
         if let result = Table.arg(vm, value: value) { return result }
         let t = value as! Table
         if !(t["w"] is Number) || !(t["h"] is Number) { return typeName }
@@ -64,7 +64,7 @@ extension Table {
 
 extension Arguments {
     
-    public var point: NSPoint { return (values.removeAtIndex(0) as! Table).toPoint()! }
-    public var size:  NSSize  { return (values.removeAtIndex(0) as! Table).toSize()!  }
+    public var point: NSPoint { return (values.remove(at: 0) as! Table).toPoint()! }
+    public var size:  NSSize  { return (values.remove(at: 0) as! Table).toSize()!  }
     
 }

--- a/Lua/Function.swift
+++ b/Lua/Function.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 public enum FunctionResults {
-    case Values([Value])
-    case Error(String)
+    case values([Value])
+    case error(String)
 }
 
-public class Function: StoredValue {
+open class Function: StoredValue {
     
-    public func call(args: [Value]) -> FunctionResults {
+    open func call(_ args: [Value]) -> FunctionResults {
         let debugTable = vm.globals["debug"] as! Table
         let messageHandler = debugTable["traceback"]
         
@@ -31,18 +31,18 @@ public class Function: StoredValue {
                 values.append(v)
             }
             
-            return .Values(values)
+            return .values(values)
         }
         else {
             let err = vm.popError()
-            return .Error(err)
+            return .error(err)
         }
     }
     
-    override public func kind() -> Kind { return .Function }
+    override open func kind() -> Kind { return .function }
     
-    override public class func arg(vm: VirtualMachine, value: Value) -> String? {
-        if value.kind() != .Function { return "function" }
+    override open class func arg(_ vm: VirtualMachine, value: Value) -> String? {
+        if value.kind() != .function { return "function" }
         return nil
     }
     
@@ -51,30 +51,30 @@ public class Function: StoredValue {
 public typealias TypeChecker = (VirtualMachine, Value) -> String?
 
 public enum SwiftReturnValue {
-    case Value(Lua.Value?)
-    case Values([Lua.Value])
-    case Nothing // convenience for Values([])
-    case Error(String)
+    case value(Lua.Value?)
+    case values([Lua.Value])
+    case nothing // convenience for Values([])
+    case error(String)
 }
 
-public typealias SwiftFunction = Arguments -> SwiftReturnValue
+public typealias SwiftFunction = (Arguments) -> SwiftReturnValue
 
-public class Arguments {
+open class Arguments {
     
     internal var values = [Value]()
     
-    public var string: String { return values.removeAtIndex(0) as! String }
-    public var number: Number { return values.removeAtIndex(0) as! Number }
-    public var boolean: Bool { return values.removeAtIndex(0) as! Bool }
-    public var function: Function { return values.removeAtIndex(0) as! Function }
-    public var table: Table { return values.removeAtIndex(0) as! Table }
-    public var userdata: Userdata { return values.removeAtIndex(0) as! Userdata }
-    public var lightUserdata: LightUserdata { return values.removeAtIndex(0) as! LightUserdata }
-    public var thread: Thread { return values.removeAtIndex(0) as! Thread }
+    open var string: String { return values.remove(at: 0) as! String }
+    open var number: Number { return values.remove(at: 0) as! Number }
+    open var boolean: Bool { return values.remove(at: 0) as! Bool }
+    open var function: Function { return values.remove(at: 0) as! Function }
+    open var table: Table { return values.remove(at: 0) as! Table }
+    open var userdata: Userdata { return values.remove(at: 0) as! Userdata }
+    open var lightUserdata: LightUserdata { return values.remove(at: 0) as! LightUserdata }
+    open var thread: Thread { return values.remove(at: 0) as! Thread }
     
-    public var integer: Int64 { return (values.removeAtIndex(0) as! Number).toInteger() }
-    public var double: Double { return (values.removeAtIndex(0) as! Number).toDouble() }
+    open var integer: Int64 { return (values.remove(at: 0) as! Number).toInteger() }
+    open var double: Double { return (values.remove(at: 0) as! Number).toDouble() }
     
-    public func customType<T: CustomTypeInstance>() -> T { return (values.removeAtIndex(0) as! Userdata).toCustomType() }
+    open func customType<T: CustomTypeInstance>() -> T { return (values.remove(at: 0) as! Userdata).toCustomType() }
     
 }

--- a/Lua/Nil.swift
+++ b/Lua/Nil.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-public class Nil: Value, Equatable {
+open class Nil: Value, Equatable {
     
-    public func push(vm: VirtualMachine) {
+    open func push(_ vm: VirtualMachine) {
         lua_pushnil(vm.vm)
     }
     
-    public func kind() -> Kind { return .Nil }
+    open func kind() -> Kind { return .nil }
     
-    public class func arg(vm: VirtualMachine, value: Value) -> String? {
-        if value.kind() != .Nil { return "nil" }
+    open class func arg(_ vm: VirtualMachine, value: Value) -> String? {
+        if value.kind() != .nil { return "nil" }
         return nil
     }
     

--- a/Lua/Number.swift
+++ b/Lua/Number.swift
@@ -1,24 +1,24 @@
 import Foundation
 
-public class Number: StoredValue, CustomDebugStringConvertible {
+open class Number: StoredValue, CustomDebugStringConvertible {
     
-    override public func kind() -> Kind { return .Number }
+    override open func kind() -> Kind { return .number }
     
-    public func toDouble() -> Double {
+    open func toDouble() -> Double {
         push(vm)
         let v = lua_tonumberx(vm.vm, -1, nil)
         vm.pop()
         return v
     }
     
-    public func toInteger() -> Int64 {
+    open func toInteger() -> Int64 {
         push(vm)
         let v = lua_tointegerx(vm.vm, -1, nil)
         vm.pop()
         return v
     }
     
-    public var debugDescription: String {
+    open var debugDescription: String {
         push(vm)
         let isInteger = lua_isinteger(vm.vm, -1) != 0
         vm.pop()
@@ -27,8 +27,8 @@ public class Number: StoredValue, CustomDebugStringConvertible {
         else { return toDouble().description }
     }
     
-    override public class func arg(vm: VirtualMachine, value: Value) -> String? {
-        if value.kind() != .Number { return "number" }
+    override open class func arg(_ vm: VirtualMachine, value: Value) -> String? {
+        if value.kind() != .number { return "number" }
         return nil
     }
     
@@ -36,13 +36,13 @@ public class Number: StoredValue, CustomDebugStringConvertible {
 
 extension Double: Value {
     
-    public func push(vm: VirtualMachine) {
+    public func push(_ vm: VirtualMachine) {
         lua_pushnumber(vm.vm, self)
     }
     
-    public func kind() -> Kind { return .Number }
+    public func kind() -> Kind { return .number }
     
-    public static func arg(vm: VirtualMachine, value: Value) -> String? {
+    public static func arg(_ vm: VirtualMachine, value: Value) -> String? {
         value.push(vm)
         let isDouble = lua_isinteger(vm.vm, -1) != 0
         vm.pop()
@@ -54,13 +54,13 @@ extension Double: Value {
 
 extension Int64: Value {
     
-    public func push(vm: VirtualMachine) {
+    public func push(_ vm: VirtualMachine) {
         lua_pushinteger(vm.vm, self)
     }
     
-    public func kind() -> Kind { return .Number }
+    public func kind() -> Kind { return .number }
     
-    public static func arg(vm: VirtualMachine, value: Value) -> String? {
+    public static func arg(_ vm: VirtualMachine, value: Value) -> String? {
         value.push(vm)
         let isDouble = lua_isinteger(vm.vm, -1) != 0
         vm.pop()
@@ -72,13 +72,13 @@ extension Int64: Value {
 
 extension Int: Value {
     
-    public func push(vm: VirtualMachine) {
+    public func push(_ vm: VirtualMachine) {
         lua_pushinteger(vm.vm, Int64(self))
     }
     
-    public func kind() -> Kind { return .Number }
+    public func kind() -> Kind { return .number }
     
-    public static func arg(vm: VirtualMachine, value: Value) -> String? {
+    public static func arg(_ vm: VirtualMachine, value: Value) -> String? {
         return Int64.arg(vm, value: value)
     }
     

--- a/Lua/String.swift
+++ b/Lua/String.swift
@@ -2,14 +2,14 @@ import Foundation
 
 extension String: Value {
     
-    public func push(vm: VirtualMachine) {
-        lua_pushstring(vm.vm, (self as NSString).UTF8String)
+    public func push(_ vm: VirtualMachine) {
+        lua_pushstring(vm.vm, (self as NSString).utf8String)
     }
     
-    public func kind() -> Kind { return .String }
+    public func kind() -> Kind { return .string }
     
-    public static func arg(vm: VirtualMachine, value: Value) -> String? {
-        if value.kind() != .String { return "string" }
+    public static func arg(_ vm: VirtualMachine, value: Value) -> String? {
+        if value.kind() != .string { return "string" }
         return nil
     }
     

--- a/Lua/Table.swift
+++ b/Lua/Table.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-public class Table: StoredValue {
+open class Table: StoredValue {
     
-    override public func kind() -> Kind { return .Table }
+    override open func kind() -> Kind { return .table }
     
-    override public class func arg(vm: VirtualMachine, value: Value) -> String? {
-        if value.kind() != .Table { return "table" }
+    override open class func arg(_ vm: VirtualMachine, value: Value) -> String? {
+        if value.kind() != .table { return "table" }
         return nil
     }
     
-    public subscript(key: Value) -> Value {
+    open subscript(key: Value) -> Value {
         get {
             push(vm)
             
@@ -32,7 +32,7 @@ public class Table: StoredValue {
         }
     }
     
-    public func keys() -> [Value] {
+    open func keys() -> [Value] {
         var k = [Value]()
         push(vm) // table
         lua_pushnil(vm.vm)
@@ -46,14 +46,14 @@ public class Table: StoredValue {
         return k
     }
     
-    public func becomeMetatableFor(thing: Value) {
+    open func becomeMetatableFor(_ thing: Value) {
         thing.push(vm)
         self.push(vm)
         lua_setmetatable(vm.vm, -2)
         vm.pop() // thing
     }
     
-    public func asTupleArray<K1: Value, V1: Value, K2: Value, V2: Value>(kfn: K1 -> K2 = {$0 as! K2}, _ vfn: V1 -> V2 = {$0 as! V2}) -> [(K2, V2)] {
+    open func asTupleArray<K1: Value, V1: Value, K2: Value, V2: Value>(_ kfn: (K1) -> K2 = {$0 as! K2}, _ vfn: (V1) -> V2 = {$0 as! V2}) -> [(K2, V2)] {
         var v = [(K2, V2)]()
         for key in keys() {
             let val = self[key]
@@ -64,7 +64,7 @@ public class Table: StoredValue {
         return v
     }
     
-    public func asDictionary<K1: Value, V1: Value, K2: Value, V2: Value where K2: Hashable>(kfn: K1 -> K2 = {$0 as! K2}, _ vfn: V1 -> V2 = {$0 as! V2}) -> [K2: V2] {
+    open func asDictionary<K1: Value, V1: Value, K2: Value, V2: Value>(_ kfn: (K1) -> K2 = {$0 as! K2}, _ vfn: (V1) -> V2 = {$0 as! V2}) -> [K2: V2] where K2: Hashable {
         var v = [K2: V2]()
         for (key, val) in asTupleArray(kfn, vfn) {
             v[key] = val
@@ -72,7 +72,7 @@ public class Table: StoredValue {
         return v
     }
     
-    public func asSequence<T: Value>() -> [T] {
+    open func asSequence<T: Value>() -> [T] {
         var sequence = [T]()
         
         let dict: [Int64 : T] = asDictionary({ (k: Number) in k.toInteger() }, { $0 as T })
@@ -81,7 +81,7 @@ public class Table: StoredValue {
         if dict.count == 0 { return sequence }
         
         // ensure table has no holes and keys start at 1
-        let sortedKeys = dict.keys.sort(<)
+        let sortedKeys = dict.keys.sorted(by: <)
         if [Int64](1...sortedKeys.last!) != sortedKeys { return sequence }
         
         // append values to the array, in order
@@ -92,12 +92,12 @@ public class Table: StoredValue {
         return sequence
     }
     
-    func storeReference(v: Value) -> Int {
+    func storeReference(_ v: Value) -> Int {
         v.push(vm)
         return vm.ref(RegistryIndex)
     }
     
-    func removeReference(ref: Int) {
+    func removeReference(_ ref: Int) {
         vm.unref(RegistryIndex, ref)
     }
     

--- a/Lua/Thread.swift
+++ b/Lua/Thread.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public class Thread: StoredValue {
+open class Thread: StoredValue {
     
-    override public func kind() -> Kind { return .Thread }
+    override open func kind() -> Kind { return .thread }
     
-    override public class func arg(vm: VirtualMachine, value: Value) -> String? {
-        if value.kind() != .Thread { return "thread" }
+    override open class func arg(_ vm: VirtualMachine, value: Value) -> String? {
+        if value.kind() != .thread { return "thread" }
         return nil
     }
     

--- a/Lua/Value.swift
+++ b/Lua/Value.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 public protocol Value {
-    func push(vm: VirtualMachine)
+    func push(_ vm: VirtualMachine)
     func kind() -> Kind
-    static func arg(vm: VirtualMachine, value: Value) -> String?
+    static func arg(_ vm: VirtualMachine, value: Value) -> String?
 }
 
-public class StoredValue: Value, Equatable {
+open class StoredValue: Value, Equatable {
     
-    private let registryLocation: Int
+    fileprivate let registryLocation: Int
     internal unowned var vm: VirtualMachine
     
     internal init(_ vm: VirtualMachine) {
@@ -21,15 +21,15 @@ public class StoredValue: Value, Equatable {
         vm.unref(RegistryIndex, registryLocation)
     }
     
-    public func push(vm: VirtualMachine) {
+    open func push(_ vm: VirtualMachine) {
         vm.rawGet(tablePosition: RegistryIndex, index: registryLocation)
     }
     
-    public func kind() -> Kind {
+    open func kind() -> Kind {
         fatalError("Override kind()")
     }
     
-    public class func arg(vm: VirtualMachine, value: Value) -> String? {
+    open class func arg(_ vm: VirtualMachine, value: Value) -> String? {
         fatalError("Override arg()")
     }
     

--- a/Lua/VirtualMachine.swift
+++ b/Lua/VirtualMachine.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Cocoa
 
 internal let RegistryIndex = Int(SDegutisLuaRegistryIndex)
 private let GlobalsTable = Int(LUA_RIDX_GLOBALS)

--- a/Lua/VirtualMachine.swift
+++ b/Lua/VirtualMachine.swift
@@ -4,45 +4,49 @@ internal let RegistryIndex = Int(SDegutisLuaRegistryIndex)
 private let GlobalsTable = Int(LUA_RIDX_GLOBALS)
 
 public enum MaybeFunction {
-    case Value(Function)
-    case Error(String)
+    case value(Function)
+    case error(String)
 }
 
 public typealias ErrorHandler = (String) -> Void
 
 public enum Kind {
-    case String
-    case Number
-    case Boolean
-    case Function
-    case Table
-    case Userdata
-    case LightUserdata
-    case Thread
-    case Nil
-    case None
+    case string
+    case number
+    case boolean
+    case function
+    case table
+    case userdata
+    case lightUserdata
+    case thread
+    case `nil`
+    case none
     
     internal func luaType() -> Int32 {
         switch self {
-        case String: return LUA_TSTRING
-        case Number: return LUA_TNUMBER
-        case Boolean: return LUA_TBOOLEAN
-        case Function: return LUA_TFUNCTION
-        case Table: return LUA_TTABLE
-        case Userdata: return LUA_TUSERDATA
-        case LightUserdata: return LUA_TLIGHTUSERDATA
-        case Thread: return LUA_TTHREAD
-        case Nil: return LUA_TNIL
-        case None: return LUA_TNONE
+        case .string: return LUA_TSTRING
+        case .number: return LUA_TNUMBER
+        case .boolean: return LUA_TBOOLEAN
+        case .function: return LUA_TFUNCTION
+        case .table: return LUA_TTABLE
+        case .userdata: return LUA_TUSERDATA
+        case .lightUserdata: return LUA_TLIGHTUSERDATA
+        case .thread: return LUA_TTHREAD
+        case nil: return LUA_TNIL
+
+        case .none:
+            fallthrough
+        default:
+            return LUA_TNONE
         }
     }
 }
 
-public class VirtualMachine {
+open class VirtualMachine {
     
     internal let vm = luaL_newstate()
     
-    public var errorHandler: ErrorHandler? = { print("error: \($0)") }
+    open var errorHandler: ErrorHandler? = { print("error: \($0)") }
     
     public init(openLibs: Bool = true) {
         if openLibs { luaL_openlibs(vm) }
@@ -52,46 +56,45 @@ public class VirtualMachine {
         lua_close(vm)
     }
     
-    internal func kind(pos: Int) -> Kind {
+    internal func kind(_ pos: Int) -> Kind {
         switch lua_type(vm, Int32(pos)) {
-        case LUA_TSTRING: return .String
-        case LUA_TNUMBER: return .Number
-        case LUA_TBOOLEAN: return .Boolean
-        case LUA_TFUNCTION: return .Function
-        case LUA_TTABLE: return .Table
-        case LUA_TUSERDATA: return .Userdata
-        case LUA_TLIGHTUSERDATA: return .LightUserdata
-        case LUA_TTHREAD: return .Thread
-        case LUA_TNIL: return .Nil
-        default: return .None
+        case LUA_TSTRING: return .string
+        case LUA_TNUMBER: return .number
+        case LUA_TBOOLEAN: return .boolean
+        case LUA_TFUNCTION: return .function
+        case LUA_TTABLE: return .table
+        case LUA_TUSERDATA: return .userdata
+        case LUA_TLIGHTUSERDATA: return .lightUserdata
+        case LUA_TTHREAD: return .thread
+        case LUA_TNIL: return .nil
+        default: return .none
         }
     }
     
     // pops the value off the stack completely and returns it
-    internal func popValue(pos: Int) -> Value? {
+    internal func popValue(_ pos: Int) -> Value? {
         moveToStackTop(pos)
         var v: Value?
         switch kind(-1) {
-        case .String:
+        case .string:
             var len: Int = 0
             let str = lua_tolstring(vm, -1, &len)
-            let data = NSData(bytes: str, length: Int(len))
-            v = NSString(data: data, encoding: NSUTF8StringEncoding)! as String
-        case .Number:
+            v = String(cString: str!)
+        case .number:
             v = Number(self)
-        case .Boolean:
+        case .boolean:
             v = lua_toboolean(vm, -1) == 1 ? true : false
-        case .Function:
+        case .function:
             v = Function(self)
-        case .Table:
+        case .table:
             v = Table(self)
-        case .Userdata:
+        case .userdata:
             v = Userdata(self)
-        case .LightUserdata:
+        case .lightUserdata:
             v = LightUserdata(self)
-        case .Thread:
+        case .thread:
             v = Thread(self)
-        case .Nil:
+        case .nil:
             v = Nil()
         default: break
         }
@@ -99,26 +102,26 @@ public class VirtualMachine {
         return v
     }
     
-    public var globals: Table {
+    open var globals: Table {
         rawGet(tablePosition: RegistryIndex, index: GlobalsTable)
         return popValue(-1) as! Table
     }
     
-    public var registry: Table {
+    open var registry: Table {
         pushFromStack(RegistryIndex)
         return popValue(-1) as! Table
     }
     
-    public func createFunction(body: String) -> MaybeFunction {
-        if luaL_loadstring(vm, (body as NSString).UTF8String) == LUA_OK {
-            return .Value(popValue(-1) as! Function)
+    open func createFunction(_ body: String) -> MaybeFunction {
+        if luaL_loadstring(vm, (body as NSString).utf8String) == LUA_OK {
+            return .value(popValue(-1) as! Function)
         }
         else {
-            return .Error(popError())
+            return .error(popError())
         }
     }
     
-    public func createTable(sequenceCapacity: Int = 0, keyCapacity: Int = 0) -> Table {
+    open func createTable(_ sequenceCapacity: Int = 0, keyCapacity: Int = 0) -> Table {
         lua_createtable(vm, Int32(sequenceCapacity), Int32(keyCapacity))
         return popValue(-1) as! Table
     }
@@ -129,44 +132,46 @@ public class VirtualMachine {
         return err
     }
     
-    public func createUserdataMaybe<T: CustomTypeInstance>(o: T?) -> Userdata? {
+    open func createUserdataMaybe<T: CustomTypeInstance>(_ o: T?) -> Userdata? {
         if let u = o {
             return createUserdata(u)
         }
         return nil
     }
     
-    public func createUserdata<T: CustomTypeInstance>(o: T) -> Userdata {
-        let ptr = UnsafeMutablePointer<T>(lua_newuserdata(vm, sizeof(T))) // this both pushes ptr onto stack and returns it
-        ptr.initialize(o) // creates a new legit reference to o
-        
-        luaL_setmetatable(vm, (T.luaTypeName() as NSString).UTF8String) // this requires ptr to be on the stack
+    open func createUserdata<T: CustomTypeInstance>(_ o: T) -> Userdata {
+        let userdata = lua_newuserdata(vm, MemoryLayout<T>.size) // this both pushes ptr onto stack and returns it
+
+        let ptr = userdata!.bindMemory(to: T.self, capacity: 1)
+        ptr.initialize(to: o) // creates a new legit reference to o
+
+        luaL_setmetatable(vm, (T.luaTypeName() as NSString).utf8String) // this requires ptr to be on the stack
         return popValue(-1) as! Userdata // this pops ptr off stack
     }
     
     public enum EvalResults {
-        case Values([Value])
-        case Error(String)
+        case values([Value])
+        case error(String)
     }
     
-    public func eval(str: String, args: [Value] = []) -> EvalResults {
+    open func eval(_ str: String, args: [Value] = []) -> EvalResults {
         let fn = createFunction(str)
         switch fn {
-        case let .Value(f):
+        case let .value(f):
             let results = f.call(args)
             switch results {
-            case let .Values(vs):
-                return .Values(vs)
-            case let .Error(e):
-                return .Error(e)
+            case let .values(vs):
+                return .values(vs)
+            case let .error(e):
+                return .error(e)
             }
-        case let .Error(e):
-            return .Error(e)
+        case let .error(e):
+            return .error(e)
         }
     }
     
-    public func createFunction(typeCheckers: [TypeChecker], _ fn: SwiftFunction) -> Function {
-        let f: @convention(block) (COpaquePointer) -> Int32 = { [weak self] _ in
+    open func createFunction(_ typeCheckers: [TypeChecker], _ fn: @escaping SwiftFunction) -> Function {
+        let f: @convention(block) (OpaquePointer) -> Int32 = { [weak self] _ in
             if self == nil { return 0 }
             let vm = self!
             
@@ -188,9 +193,9 @@ public class VirtualMachine {
             
             // call fn
             switch fn(args) {
-            case .Nothing:
+            case .nothing:
                 return 0
-            case let .Value(value):
+            case let .value(value):
                 if let v = value {
                     v.push(vm)
                 }
@@ -198,33 +203,31 @@ public class VirtualMachine {
                     Nil().push(vm)
                 }
                 return 1
-            case let .Values(values):
+            case let .values(values):
                 for value in values {
                     value.push(vm)
                 }
                 return Int32(values.count)
-            case let .Error(error):
+            case let .error(error):
                 print("pushing error: \(error)")
                 error.push(vm)
                 lua_error(vm.vm)
                 return 0 // uhh, we don't actually get here
             }
         }
-        let block: AnyObject = unsafeBitCast(f, AnyObject.self)
+        let block: AnyObject = unsafeBitCast(f, to: AnyObject.self)
         let imp = imp_implementationWithBlock(block)
         
-        typealias CFunction = @convention(c) (COpaquePointer) -> Int32
-        let fp = unsafeBitCast(imp, CFunction.self)
+        let fp = unsafeBitCast(imp, to: lua_CFunction.self)
         lua_pushcclosure(vm, fp, 0)
         return popValue(-1) as! Function
     }
     
-    @noreturn
-    private func argError(expectedType: String, at argPosition: Int) -> Int32 {
-        luaL_typerror(vm, Int32(argPosition), (expectedType as NSString).UTF8String)
+    fileprivate func argError(_ expectedType: String, at argPosition: Int) {
+        luaL_typerror(vm, Int32(argPosition), (expectedType as NSString).utf8String)
     }
     
-    public func createCustomType<T: CustomTypeInstance>(setup: (CustomType<T>) -> Void) -> CustomType<T> {
+    open func createCustomType<T: CustomTypeInstance>(_ setup: (CustomType<T>) -> Void) -> CustomType<T> {
         lua_createtable(vm, 0, 0)
         let lib = CustomType<T>(self)
         pop()
@@ -239,17 +242,17 @@ public class VirtualMachine {
         let gc = lib.gc
         lib["__gc"] = createFunction([CustomType<T>.arg]) { args in
             let ud = args.userdata
-            (ud.userdataPointer() as UnsafeMutablePointer<Void>).destroy()
+            (ud.userdataPointer() as UnsafeMutablePointer<T>).deinitialize()
             let o: T = ud.toCustomType()
             gc?(o)
-            return .Nothing
+            return .nothing
         }
         
         if let eq = lib.eq {
             lib["__eq"] = createFunction([CustomType<T>.arg, CustomType<T>.arg]) { args in
                 let a: T = args.customType()
                 let b: T = args.customType()
-                return .Value(eq(a, b))
+                return .value(eq(a, b))
             }
         }
         return lib
@@ -257,31 +260,32 @@ public class VirtualMachine {
     
     // stack
     
-    internal func moveToStackTop(var position: Int) {
+    internal func moveToStackTop(_ position: Int) {
+        var position = position
         if position == -1 || position == stackSize() { return }
         position = absolutePosition(position)
         pushFromStack(position)
         remove(position)
     }
     
-    internal func ref(position: Int) -> Int { return Int(luaL_ref(vm, Int32(position))) }
-    internal func unref(table: Int, _ position: Int) { luaL_unref(vm, Int32(table), Int32(position)) }
-    internal func absolutePosition(position: Int) -> Int { return Int(lua_absindex(vm, Int32(position))) }
-    internal func rawGet(tablePosition tablePosition: Int, index: Int) { lua_rawgeti(vm, Int32(tablePosition), lua_Integer(index)) }
+    internal func ref(_ position: Int) -> Int { return Int(luaL_ref(vm, Int32(position))) }
+    internal func unref(_ table: Int, _ position: Int) { luaL_unref(vm, Int32(table), Int32(position)) }
+    internal func absolutePosition(_ position: Int) -> Int { return Int(lua_absindex(vm, Int32(position))) }
+    internal func rawGet(tablePosition: Int, index: Int) { lua_rawgeti(vm, Int32(tablePosition), lua_Integer(index)) }
     
-    internal func pushFromStack(position: Int) {
+    internal func pushFromStack(_ position: Int) {
         lua_pushvalue(vm, Int32(position))
     }
     
-    internal func pop(n: Int = 1) {
+    internal func pop(_ n: Int = 1) {
         lua_settop(vm, -Int32(n)-1)
     }
     
-    internal func rotate(position: Int, n: Int) {
+    internal func rotate(_ position: Int, n: Int) {
         lua_rotate(vm, Int32(position), Int32(n))
     }
     
-    internal func remove(position: Int) {
+    internal func remove(_ position: Int) {
         rotate(position, n: -1)
         pop(1)
     }


### PR DESCRIPTION
Hi,

I'm trying to use lua4swift in iOS projects and found that the VirtualMachine.swift file is importing Cocoa. I've look at the rest of the source and finds nothing requires Cocoa so I'm submitting this pull request to remove that import so lua4swift can be used on iOS.

One side question, has lua4swift ever been tested on iOS? Will there be any interest in supporting iOS?